### PR TITLE
Technical debt - move WorkflowHandler to portal-workflow-api

### DIFF
--- a/modules/apps/account/account-service/build.gradle
+++ b/modules/apps/account/account-service/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-runtime-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/workflow/AccountEntryWorkflowHandler.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/workflow/AccountEntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/blogs/blogs-service/build.gradle
+++ b/modules/apps/blogs/blogs-service/build.gradle
@@ -40,4 +40,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/workflow/BlogsEntryWorkflowHandler.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/workflow/BlogsEntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/calendar/calendar-service/build.gradle
+++ b/modules/apps/calendar/calendar-service/build.gradle
@@ -47,4 +47,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/workflow/CalendarBookingWorkflowHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/workflow/CalendarBookingWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/client-extension/client-extension-service/build.gradle
+++ b/modules/apps/client-extension/client-extension-service/build.gradle
@@ -22,4 +22,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/workflow/ClientExtensionEntryWorkflowHandler.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/workflow/ClientExtensionEntryWorkflowHandler.java
@@ -19,15 +19,15 @@ import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-discount-service/build.gradle
+++ b/modules/apps/commerce/commerce-discount-service/build.gradle
@@ -26,4 +26,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/internal/workflow/CommerceDiscountWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/internal/workflow/CommerceDiscountWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-order-rule-service/build.gradle
+++ b/modules/apps/commerce/commerce-order-rule-service/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/internal/workflow/COREntryWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/internal/workflow/COREntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-price-list-service/build.gradle
+++ b/modules/apps/commerce/commerce-price-list-service/build.gradle
@@ -29,4 +29,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/workflow/CommercePriceEntryWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/workflow/CommercePriceEntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/workflow/CommercePriceListWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/workflow/CommercePriceListWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/workflow/CommerceTierPriceEntryWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/workflow/CommerceTierPriceEntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-pricing-service/build.gradle
+++ b/modules/apps/commerce/commerce-pricing-service/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/internal/workflow/CommercePriceModifierWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/internal/workflow/CommercePriceModifierWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-product-service/build.gradle
+++ b/modules/apps/commerce/commerce-product-service/build.gradle
@@ -56,4 +56,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPAttachmentFileEntryWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPAttachmentFileEntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPDefinitionLinkWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPDefinitionLinkWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPDefinitionWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPDefinitionWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPInstanceWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/workflow/CPInstanceWorkflowHandler.java
@@ -19,15 +19,15 @@ import com.liferay.commerce.product.service.CPInstanceLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-service/build.gradle
+++ b/modules/apps/commerce/commerce-service/build.gradle
@@ -51,4 +51,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/workflow/CommerceOrderTypeWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/workflow/CommerceOrderTypeWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/workflow/CommerceOrderWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/workflow/CommerceOrderWorkflowHandler.java
@@ -23,15 +23,15 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/commerce/commerce-term-service/build.gradle
+++ b/modules/apps/commerce/commerce-term-service/build.gradle
@@ -26,4 +26,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/internal/workflow/CommerceTermEntryWorkflowHandler.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/internal/workflow/CommerceTermEntryWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-sql-dsl-spi")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 
 	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":apps:portal-search:portal-search-test-util")

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/workflow/DLFileEntryWorkflowHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/workflow/DLFileEntryWorkflowHandler.java
@@ -33,15 +33,15 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }
 
 liferayOSGi {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/workflow/DDLFormWorkflowHandler.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/workflow/DDLFormWorkflowHandler.java
@@ -29,15 +29,15 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/workflow/DDLRecordWorkflowHandler.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/workflow/DDLRecordWorkflowHandler.java
@@ -27,15 +27,15 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-sql-dsl-spi")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 
 	testCompile group: "org.json", name: "json", version: "20230227"
 	testCompile group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/workflow/DDMFormInstanceRecordWorkflowHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/workflow/DDMFormInstanceRecordWorkflowHandler.java
@@ -27,15 +27,15 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/journal/journal-service/build.gradle
+++ b/modules/apps/journal/journal-service/build.gradle
@@ -68,4 +68,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-sql-dsl-spi")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/workflow/JournalArticleWorkflowHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/workflow/JournalArticleWorkflowHandler.java
@@ -29,15 +29,15 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/knowledge-base/knowledge-base-service/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-service/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 
 	testCompile group: "org.pegdown", name: "pegdown", version: "1.1.0"
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/workflow/KBArticleWorkflowHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/workflow/KBArticleWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutRevisionWorkflowHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutRevisionWorkflowHandler.java
@@ -20,15 +20,15 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutWorkflowHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutWorkflowHandler.java
@@ -42,9 +42,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
@@ -54,6 +52,8 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;

--- a/modules/apps/message-boards/message-boards-service/build.gradle
+++ b/modules/apps/message-boards/message-boards-service/build.gradle
@@ -42,4 +42,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/BaseMBWorkflowHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/BaseMBWorkflowHandler.java
@@ -19,8 +19,8 @@ import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
 
 import java.io.Serializable;
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/MBDiscussionWorkflowHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/MBDiscussionWorkflowHandler.java
@@ -24,13 +24,13 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
 
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/MBMessageWorkflowHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/MBMessageWorkflowHandler.java
@@ -17,10 +17,10 @@ package com.liferay.message.boards.internal.workflow;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.util.Locale;
 
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/object/object-service/build.gradle
+++ b/modules/apps/object/object-service/build.gradle
@@ -56,5 +56,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-sql-dsl-spi")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -75,7 +75,6 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
@@ -83,6 +82,7 @@ import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterC
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
 import com.liferay.user.associated.data.display.UADDisplay;
 import com.liferay.user.associated.data.exporter.UADExporter;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
@@ -25,8 +25,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
 
 import java.io.Serializable;
 

--- a/modules/apps/portal-workflow/portal-workflow-api/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-api/build.gradle
@@ -7,4 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":core:osgi-service-tracker-collections")
 }

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/BaseWorkflowHandler.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/BaseWorkflowHandler.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.handler;
+
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.petra.function.UnsafeBiFunction;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+import javax.portlet.WindowState;
+import javax.portlet.WindowStateException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Bruno Farache
+ * @author Marcellus Tavares
+ * @author Juan Fernández
+ * @author Julio Camarero
+ * @author Jorge Ferrer
+ */
+public abstract class BaseWorkflowHandler<T> implements WorkflowHandler<T> {
+
+	@Override
+	public AssetRenderer<T> getAssetRenderer(long classPK)
+		throws PortalException {
+
+		AssetRendererFactory<T> assetRendererFactory =
+			getAssetRendererFactory();
+
+		if (assetRendererFactory != null) {
+			return assetRendererFactory.getAssetRenderer(
+				classPK, AssetRendererFactory.TYPE_LATEST);
+		}
+
+		return null;
+	}
+
+	@Override
+	public AssetRendererFactory<T> getAssetRendererFactory() {
+		return (AssetRendererFactory<T>)
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				getClassName());
+	}
+
+	@Override
+	public String getIconCssClass() {
+		AssetRendererFactory<?> assetRendererFactory =
+			getAssetRendererFactory();
+
+		if (assetRendererFactory != null) {
+			return assetRendererFactory.getIconCssClass();
+		}
+
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String getNotificationLink(
+			long workflowTaskId, ServiceContext serviceContext)
+		throws PortalException {
+
+		try {
+			PortletURL portletURL = PortalUtil.getControlPanelPortletURL(
+				serviceContext.getRequest(), serviceContext.getScopeGroup(),
+				PortletKeys.MY_WORKFLOW_TASK, 0, 0,
+				PortletRequest.RENDER_PHASE);
+
+			portletURL.setParameter("mvcPath", "/edit_workflow_task.jsp");
+			portletURL.setParameter(
+				"workflowTaskId", String.valueOf(workflowTaskId));
+			portletURL.setWindowState(WindowState.MAXIMIZED);
+
+			return portletURL.toString();
+		}
+		catch (WindowStateException windowStateException) {
+			throw new PortalException(windowStateException);
+		}
+	}
+
+	@Override
+	public String getSummary(
+		long classPK, PortletRequest portletRequest,
+		PortletResponse portletResponse) {
+
+		try {
+			AssetRenderer<?> assetRenderer = getAssetRenderer(classPK);
+
+			if (assetRenderer != null) {
+				return assetRenderer.getSummary(
+					portletRequest, portletResponse);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getTitle(long classPK, Locale locale) {
+		try {
+			AssetRenderer<?> assetRenderer = getAssetRenderer(classPK);
+
+			if (assetRenderer != null) {
+				return assetRenderer.getTitle(locale);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		try {
+			AssetRenderer<?> assetRenderer = getAssetRenderer(classPK);
+
+			if (assetRenderer != null) {
+				return assetRenderer.getURLEdit(
+					liferayPortletRequest, liferayPortletResponse);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public PortletURL getURLViewDiffs(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		try {
+			AssetRenderer<?> assetRenderer = getAssetRenderer(classPK);
+
+			if (assetRenderer != null) {
+				return assetRenderer.getURLViewDiffs(
+					liferayPortletRequest, liferayPortletResponse);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getURLViewInContext(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
+
+		try {
+			AssetRenderer<?> assetRenderer = getAssetRenderer(classPK);
+
+			if (assetRenderer != null) {
+				return assetRenderer.getURLViewInContext(
+					liferayPortletRequest, liferayPortletResponse,
+					noSuchEntryRedirect);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @throws PortalException
+	 */
+	@Override
+	public WorkflowDefinitionLink getWorkflowDefinitionLink(
+			long companyId, long groupId, long classPK)
+		throws PortalException {
+
+		return WorkflowDefinitionLinkLocalServiceUtil.
+			fetchWorkflowDefinitionLink(
+				companyId, groupId, getClassName(), 0, 0);
+	}
+
+	@Override
+	public boolean include(
+		long classPK, HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String template) {
+
+		try {
+			AssetRenderer<?> assetRenderer = getAssetRenderer(classPK);
+
+			if (assetRenderer != null) {
+				return assetRenderer.include(
+					httpServletRequest, httpServletResponse, template);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isAssetTypeSearchable() {
+		return _ASSET_TYPE_SEARCHABLE;
+	}
+
+	@Override
+	public boolean isScopeable() {
+		return _SCOPEABLE;
+	}
+
+	@Override
+	public boolean isVisible() {
+		return _VISIBLE;
+	}
+
+	@Override
+	public void startWorkflowInstance(
+			long companyId, long groupId, long userId, long classPK, T model,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		WorkflowInstanceLinkLocalServiceUtil.startWorkflowInstance(
+			companyId, groupId, userId, getClassName(), classPK,
+			workflowContext);
+	}
+
+	private static final boolean _ASSET_TYPE_SEARCHABLE = true;
+
+	private static final boolean _SCOPEABLE = true;
+
+	private static final boolean _VISIBLE = true;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseWorkflowHandler.class);
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/WorkflowHandler.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/WorkflowHandler.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.handler;
+
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.petra.function.UnsafeBiFunction;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Bruno Farache
+ * @author Macerllus Tavares
+ * @author Juan Fernández
+ * @author Julio Camarero
+ */
+public interface WorkflowHandler<T> {
+
+	public AssetRenderer<T> getAssetRenderer(long classPK)
+		throws PortalException;
+
+	public AssetRendererFactory<T> getAssetRendererFactory();
+
+	public String getClassName();
+
+	public default long getDiscussionClassPK(
+		Map<String, Serializable> workflowContext) {
+
+		return GetterUtil.getLong(
+			workflowContext.get(WorkflowConstants.CONTEXT_ENTRY_CLASS_PK));
+	}
+
+	public String getIconCssClass();
+
+	public default String getNotificationLink(
+			long workflowTaskId, ServiceContext serviceContext)
+		throws PortalException {
+
+		return StringPool.BLANK;
+	}
+
+	public String getSummary(
+		long classPK, PortletRequest portletRequest,
+		PortletResponse portletResponse);
+
+	public String getTitle(long classPK, Locale locale);
+
+	public String getType(Locale locale);
+
+	public PortletURL getURLEdit(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse);
+
+	public PortletURL getURLViewDiffs(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse);
+
+	public String getURLViewInContext(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect);
+
+	public WorkflowDefinitionLink getWorkflowDefinitionLink(
+			long companyId, long groupId, long classPK)
+		throws PortalException;
+
+	public boolean include(
+		long classPK, HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String template);
+
+	public boolean isAssetTypeSearchable();
+
+	public default boolean isCommentable() {
+		return true;
+	}
+
+	public boolean isScopeable();
+
+	public boolean isVisible();
+
+	public default boolean isVisible(Group group) {
+		return isVisible();
+	}
+
+	public void startWorkflowInstance(
+			long companyId, long groupId, long userId, long classPK, T model,
+			Map<String, Serializable> workflowContext)
+		throws PortalException;
+
+	public T updateStatus(int status, Map<String, Serializable> workflowContext)
+		throws PortalException;
+
+	public default T updateStatus(
+			T model, int status, Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		return updateStatus(status, workflowContext);
+	}
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/WorkflowHandlerRegistryUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/WorkflowHandlerRegistryUtil.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.handler;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapper;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowEngineManagerUtil;
+import com.liferay.portal.kernel.workflow.WorkflowException;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowInstance;
+import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
+import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * @author Bruno Farache
+ * @author Marcellus Tavares
+ */
+public class WorkflowHandlerRegistryUtil {
+
+	public static List<WorkflowHandler<?>> getScopeableWorkflowHandlers() {
+		return _getWorkflowHandlers(_scopeableWorkflowHandlerServiceTrackerMap);
+	}
+
+	public static <T> WorkflowHandler<T> getWorkflowHandler(String className) {
+		return (WorkflowHandler<T>)_workflowHandlerServiceTrackerMap.getService(
+			className);
+	}
+
+	public static List<WorkflowHandler<?>> getWorkflowHandlers() {
+		return _getWorkflowHandlers(_workflowHandlerServiceTrackerMap);
+	}
+
+	public static <T> void startWorkflowInstance(
+			long companyId, long groupId, long userId, String className,
+			long classPK, T model, ServiceContext serviceContext)
+		throws PortalException {
+
+		Map<String, Serializable> workflowContext =
+			(Map<String, Serializable>)serviceContext.removeAttribute(
+				"workflowContext");
+
+		if (workflowContext == null) {
+			workflowContext = Collections.emptyMap();
+		}
+
+		startWorkflowInstance(
+			companyId, groupId, userId, className, classPK, model,
+			serviceContext, workflowContext);
+	}
+
+	public static <T> T startWorkflowInstance(
+			long companyId, long groupId, long userId, String className,
+			long classPK, T model, ServiceContext serviceContext,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		if (serviceContext.getWorkflowAction() !=
+			WorkflowConstants.ACTION_PUBLISH) {
+
+			return model;
+		}
+
+		WorkflowHandler<T> workflowHandler = getWorkflowHandler(className);
+
+		if (workflowHandler == null) {
+			if (WorkflowThreadLocal.isEnabled()) {
+				throw new WorkflowException(
+					"No workflow handler found for " + className);
+			}
+
+			return model;
+		}
+
+		boolean hasWorkflowInstanceInProgress = _hasWorkflowInstanceInProgress(
+			companyId, groupId, className, classPK);
+
+		if (hasWorkflowInstanceInProgress) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Workflow already started for class ", className,
+						" with primary key ", classPK, " in group ", groupId));
+			}
+
+			return model;
+		}
+
+		WorkflowDefinitionLink workflowDefinitionLink = null;
+
+		if (WorkflowThreadLocal.isEnabled() &&
+			WorkflowEngineManagerUtil.isDeployed()) {
+
+			workflowDefinitionLink = workflowHandler.getWorkflowDefinitionLink(
+				companyId, groupId, classPK);
+		}
+
+		int status = WorkflowConstants.STATUS_PENDING;
+
+		if (workflowDefinitionLink == null) {
+			status = WorkflowConstants.STATUS_APPROVED;
+		}
+
+		workflowContext = HashMapBuilder.create(
+			workflowContext
+		).put(
+			WorkflowConstants.CONTEXT_COMPANY_ID, String.valueOf(companyId)
+		).put(
+			WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME, className
+		).put(
+			WorkflowConstants.CONTEXT_ENTRY_CLASS_PK, String.valueOf(classPK)
+		).put(
+			WorkflowConstants.CONTEXT_ENTRY_TYPE,
+			workflowHandler.getType(LocaleUtil.getDefault())
+		).put(
+			WorkflowConstants.CONTEXT_GROUP_ID, String.valueOf(groupId)
+		).put(
+			WorkflowConstants.CONTEXT_SERVICE_CONTEXT, serviceContext
+		).put(
+			WorkflowConstants.CONTEXT_TASK_COMMENTS,
+			GetterUtil.getString(serviceContext.getAttribute("comments"))
+		).put(
+			WorkflowConstants.CONTEXT_USER_ID, String.valueOf(userId)
+		).build();
+
+		T updatedModel = workflowHandler.updateStatus(
+			model, status, workflowContext);
+
+		if (workflowDefinitionLink != null) {
+			Map<String, Serializable> tempWorkflowContext = workflowContext;
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					if (!_hasWorkflowInstanceInProgress(
+							companyId, groupId, className, classPK)) {
+
+						workflowHandler.startWorkflowInstance(
+							companyId, groupId, userId, classPK, model,
+							tempWorkflowContext);
+					}
+
+					return null;
+				});
+		}
+
+		return updatedModel;
+	}
+
+	public static <T> void startWorkflowInstance(
+			long companyId, long userId, String className, long classPK,
+			T model, ServiceContext serviceContext)
+		throws PortalException {
+
+		Map<String, Serializable> workflowContext =
+			(Map<String, Serializable>)serviceContext.removeAttribute(
+				"workflowContext");
+
+		if (workflowContext == null) {
+			workflowContext = Collections.emptyMap();
+		}
+
+		startWorkflowInstance(
+			companyId, WorkflowConstants.DEFAULT_GROUP_ID, userId, className,
+			classPK, model, serviceContext, workflowContext);
+	}
+
+	public static <T> void startWorkflowInstance(
+			long companyId, long userId, String className, long classPK,
+			T model, ServiceContext serviceContext,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		startWorkflowInstance(
+			companyId, WorkflowConstants.DEFAULT_GROUP_ID, userId, className,
+			classPK, model, serviceContext, workflowContext);
+	}
+
+	public static <T> T updateStatus(
+			int status, Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		String className = (String)workflowContext.get(
+			WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME);
+
+		com.liferay.portal.kernel.workflow.WorkflowHandler<T> workflowHandler = getWorkflowHandler(className);
+
+		if (workflowHandler != null) {
+			return workflowHandler.updateStatus(status, workflowContext);
+		}
+
+		return null;
+	}
+
+	private static List<WorkflowHandler<?>> _getWorkflowHandlers(
+		ServiceTrackerMap<String, WorkflowHandler<?>>
+			workflowHandlerServiceTrackerMap) {
+
+		List<WorkflowHandler<?>> workflowHandlers = new ArrayList<>();
+
+		for (String modelClassName :
+				workflowHandlerServiceTrackerMap.keySet()) {
+
+			workflowHandlers.add(
+				workflowHandlerServiceTrackerMap.getService(modelClassName));
+		}
+
+		return workflowHandlers;
+	}
+
+	private static boolean _hasWorkflowInstanceInProgress(
+			long companyId, long groupId, String className, long classPK)
+		throws PortalException {
+
+		WorkflowInstanceLink workflowInstanceLink =
+			WorkflowInstanceLinkLocalServiceUtil.fetchWorkflowInstanceLink(
+				companyId, groupId, className, classPK);
+
+		if (workflowInstanceLink == null) {
+			return false;
+		}
+
+		WorkflowInstance workflowInstance =
+			WorkflowInstanceManagerUtil.getWorkflowInstance(
+				companyId, workflowInstanceLink.getWorkflowInstanceId());
+
+		if (!workflowInstance.isComplete()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		WorkflowHandlerRegistryUtil.class);
+
+	private static final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+	private static final ServiceTrackerMap<String, WorkflowHandler<?>>
+		_scopeableWorkflowHandlerServiceTrackerMap;
+	private static final ServiceTrackerMap<String, WorkflowHandler<?>>
+		_workflowHandlerServiceTrackerMap;
+
+	private static class WorkflowHandlerServiceReferenceMapper
+		implements ServiceReferenceMapper<String, WorkflowHandler<?>> {
+
+		@Override
+		public void map(
+			ServiceReference<WorkflowHandler<?>> serviceReference,
+			Emitter<String> emitter) {
+
+			WorkflowHandler<?>
+				workflowHandler = _bundleContext.getService(
+				serviceReference);
+
+			if (_predicate.test(workflowHandler)) {
+				emitter.emit(workflowHandler.getClassName());
+			}
+		}
+
+		private WorkflowHandlerServiceReferenceMapper(
+			Predicate<WorkflowHandler<?>> predicate) {
+
+			_predicate = predicate;
+		}
+
+		private final Predicate<WorkflowHandler<?>> _predicate;
+
+	}
+
+	static {
+		_workflowHandlerServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext,
+				(Class<com.liferay.portal.kernel.workflow.WorkflowHandler<?>>)(Class<?>) com.liferay.portal.kernel.workflow.WorkflowHandler.class,
+				null,
+				new WorkflowHandlerServiceReferenceMapper(handler -> true));
+
+		_scopeableWorkflowHandlerServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext,
+				(Class<com.liferay.portal.kernel.workflow.WorkflowHandler<?>>)(Class<?>) WorkflowHandler.class,
+				null,
+				new WorkflowHandlerServiceReferenceMapper(
+					handler -> handler.isScopeable()));
+	}
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/WorkflowHandlerWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/handler/WorkflowHandlerWrapper.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.handler;
+
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.petra.function.UnsafeBiFunction;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.service.ServiceContext;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class WorkflowHandlerWrapper<T> implements WorkflowHandler<T> {
+
+	public WorkflowHandlerWrapper(WorkflowHandler<T> workflowHandler) {
+		_workflowHandler = workflowHandler;
+	}
+
+	@Override
+	public AssetRenderer<T> getAssetRenderer(long classPK)
+		throws PortalException {
+
+		return _workflowHandler.getAssetRenderer(classPK);
+	}
+
+	@Override
+	public AssetRendererFactory<T> getAssetRendererFactory() {
+		return _workflowHandler.getAssetRendererFactory();
+	}
+
+	@Override
+	public String getClassName() {
+		return _workflowHandler.getClassName();
+	}
+
+	@Override
+	public long getDiscussionClassPK(
+		Map<String, Serializable> workflowContext) {
+
+		return _workflowHandler.getDiscussionClassPK(workflowContext);
+	}
+
+	@Override
+	public String getIconCssClass() {
+		return _workflowHandler.getIconCssClass();
+	}
+
+	@Override
+	public String getNotificationLink(
+			long workflowTaskId, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _workflowHandler.getNotificationLink(
+			workflowTaskId, serviceContext);
+	}
+
+	@Override
+	public String getSummary(
+		long classPK, PortletRequest portletRequest,
+		PortletResponse portletResponse) {
+
+		return _workflowHandler.getSummary(
+			classPK, portletRequest, portletResponse);
+	}
+
+	@Override
+	public String getTitle(long classPK, Locale locale) {
+		return _workflowHandler.getTitle(classPK, locale);
+	}
+
+	@Override
+	public String getType(Locale locale) {
+		return _workflowHandler.getType(locale);
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return _workflowHandler.getURLEdit(
+			classPK, liferayPortletRequest, liferayPortletResponse);
+	}
+
+	@Override
+	public PortletURL getURLViewDiffs(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return _workflowHandler.getURLViewDiffs(
+			classPK, liferayPortletRequest, liferayPortletResponse);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
+
+		return _workflowHandler.getURLViewInContext(
+			classPK, liferayPortletRequest, liferayPortletResponse,
+			noSuchEntryRedirect);
+	}
+
+	@Override
+	public WorkflowDefinitionLink getWorkflowDefinitionLink(
+			long companyId, long groupId, long classPK)
+		throws PortalException {
+
+		return _workflowHandler.getWorkflowDefinitionLink(
+			companyId, groupId, classPK);
+	}
+
+	@Override
+	public boolean include(
+		long classPK, HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String template) {
+
+		return _workflowHandler.include(
+			classPK, httpServletRequest, httpServletResponse, template);
+	}
+
+	@Override
+	public boolean isAssetTypeSearchable() {
+		return _workflowHandler.isAssetTypeSearchable();
+	}
+
+	@Override
+	public boolean isCommentable() {
+		return _workflowHandler.isCommentable();
+	}
+
+	@Override
+	public boolean isScopeable() {
+		return _workflowHandler.isScopeable();
+	}
+
+	@Override
+	public boolean isVisible() {
+		return _workflowHandler.isVisible();
+	}
+
+	@Override
+	public boolean isVisible(Group group) {
+		return _workflowHandler.isVisible(group);
+	}
+
+	@Override
+	public void startWorkflowInstance(
+			long companyId, long groupId, long userId, long classPK, T model,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		_workflowHandler.startWorkflowInstance(
+			companyId, groupId, userId, classPK, model, workflowContext);
+	}
+
+	@Override
+	public T updateStatus(int status, Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		return _workflowHandler.updateStatus(status, workflowContext);
+	}
+
+	@Override
+	public T updateStatus(
+			T model, int status, Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		return _workflowHandler.updateStatus(model, status, workflowContext);
+	}
+
+	private final WorkflowHandler<T> _workflowHandler;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/WorkflowTaskPermissionImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/WorkflowTaskPermissionImplTest.java
@@ -25,14 +25,14 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.DefaultWorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
 import com.liferay.portal.security.permission.SimplePermissionChecker;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import com.liferay.portal.workflow.kaleo.runtime.integration.internal.WorkflowTaskManagerImpl;
 import com.liferay.portal.workflow.security.permission.WorkflowTaskPermission;
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -33,13 +33,13 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ProxyFactory;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.DefaultWorkflowTask;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import com.liferay.portal.workflow.security.permission.WorkflowTaskPermission;
 
 import java.io.Serializable;

--- a/modules/apps/translation/translation-service/build.gradle
+++ b/modules/apps/translation/translation-service/build.gradle
@@ -39,4 +39,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/workflow/TranslationEntryWorkflowHandler.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/workflow/TranslationEntryWorkflowHandler.java
@@ -18,9 +18,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
 

--- a/modules/apps/users-admin/users-admin-impl/build.gradle
+++ b/modules/apps/users-admin/users-admin-impl/build.gradle
@@ -16,4 +16,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java
@@ -22,9 +22,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
 import java.io.Serializable;
 
@@ -34,6 +31,8 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/modules/apps/wiki/wiki-web/build.gradle
+++ b/modules/apps/wiki/wiki-web/build.gradle
@@ -48,4 +48,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/workflow/WikiPageWorkflowHandler.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/workflow/WikiPageWorkflowHandler.java
@@ -18,9 +18,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiPageLocalService;
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/build.gradle
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/build.gradle
@@ -23,4 +23,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:portal-workflow:portal-workflow-kaleo-forms-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/src/main/java/com/liferay/portal/workflow/kaleo/forms/internal/workflow/KaleoProcessWorkflowHandler.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-service/src/main/java/com/liferay/portal/workflow/kaleo/forms/internal/workflow/KaleoProcessWorkflowHandler.java
@@ -26,9 +26,9 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.workflow.handler.BaseWorkflowHandler;
+import com.liferay.portal.workflow.handler.WorkflowHandler;
 import com.liferay.portal.workflow.kaleo.forms.model.KaleoProcess;
 import com.liferay.portal.workflow.kaleo.forms.service.KaleoProcessLocalService;
 

--- a/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
@@ -70,7 +70,6 @@ import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webdav.WebDAVStorage;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.xml.QName;
 import com.liferay.portal.kernel.xmlrpc.Method;
 import com.liferay.portal.util.PropsValues;
@@ -2244,22 +2243,6 @@ public class PortletImpl extends PortletBaseImpl {
 	@Override
 	public List<String> getWorkflowHandlerClasses() {
 		return _workflowHandlerClasses;
-	}
-
-	/**
-	 * Returns the workflow handler instances of the portlet.
-	 *
-	 * @return the workflow handler instances of the portlet
-	 */
-	@Override
-	public List<WorkflowHandler<?>> getWorkflowHandlerInstances() {
-		if (_workflowHandlerClasses.isEmpty()) {
-			return null;
-		}
-
-		PortletBag portletBag = PortletBagPool.get(getRootPortletId());
-
-		return portletBag.getWorkflowHandlerInstances();
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/WorkflowInstanceLinkLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/WorkflowInstanceLinkLocalServiceImpl.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.DefaultWorkflowNode;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;

--- a/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
@@ -64,7 +64,6 @@ import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webdav.WebDAVStorage;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;

--- a/portal-impl/src/com/liferay/portlet/internal/PortletBagImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletBagImpl.java
@@ -42,7 +42,6 @@ import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.webdav.WebDAVStorage;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.xmlrpc.Method;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.social.kernel.model.SocialActivityInterpreter;
@@ -281,11 +280,6 @@ public class PortletBagImpl implements PortletBag {
 	@Override
 	public List<WebDAVStorage> getWebDAVStorageInstances() {
 		return _getList(WebDAVStorage.class);
-	}
-
-	@Override
-	public List<WorkflowHandler<?>> getWorkflowHandlerInstances() {
-		return _getList(WorkflowHandler.class);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/model/Portlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/Portlet.java
@@ -1248,14 +1248,6 @@ public interface Portlet extends PersistedModel, PortletModel {
 	public java.util.List<String> getWorkflowHandlerClasses();
 
 	/**
-	 * Returns the workflow handler instances of the portlet.
-	 *
-	 * @return the workflow handler instances of the portlet
-	 */
-	public java.util.List<com.liferay.portal.kernel.workflow.WorkflowHandler<?>>
-		getWorkflowHandlerInstances();
-
-	/**
 	 * Returns the name of the XML-RPC method class of the portlet.
 	 *
 	 * @return the name of the XML-RPC method class of the portlet

--- a/portal-kernel/src/com/liferay/portal/kernel/model/PortletWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/PortletWrapper.java
@@ -1817,18 +1817,6 @@ public class PortletWrapper
 	}
 
 	/**
-	 * Returns the workflow handler instances of the portlet.
-	 *
-	 * @return the workflow handler instances of the portlet
-	 */
-	@Override
-	public java.util.List<com.liferay.portal.kernel.workflow.WorkflowHandler<?>>
-		getWorkflowHandlerInstances() {
-
-		return model.getWorkflowHandlerInstances();
-	}
-
-	/**
 	 * Returns the name of the XML-RPC method class of the portlet.
 	 *
 	 * @return the name of the XML-RPC method class of the portlet

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletBag.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletBag.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.servlet.URLEncoder;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.webdav.WebDAVStorage;
-import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.xmlrpc.Method;
 import com.liferay.social.kernel.model.SocialActivityInterpreter;
 import com.liferay.social.kernel.model.SocialRequestInterpreter;
@@ -111,8 +110,6 @@ public interface PortletBag extends Cloneable {
 	public List<UserNotificationHandler> getUserNotificationHandlerInstances();
 
 	public List<WebDAVStorage> getWebDAVStorageInstances();
-
-	public List<WorkflowHandler<?>> getWorkflowHandlerInstances();
 
 	public List<Method> getXmlRpcMethodInstances();
 


### PR DESCRIPTION
the WorkflowHandler is used in WorkflowInstanceLinkLocalServiceImpl that is used in some other services in portal-impl like UserLocalServiceImpl,

but it's only used to invoke deleteWorkflowInstanceLinks, I'm wondering if we can move this logic to UserModelListeners for example.