### PR TITLE
LPS-189313 Failing virtual instance creation leaves behind orphaned workflow metrics indices

### DIFF
--- a/modules/apps/portal/portal-instance-lifecycle-api/src/main/java/com/liferay/portal/instance/lifecycle/PortalInstanceLifecycleListener.java
+++ b/modules/apps/portal/portal-instance-lifecycle-api/src/main/java/com/liferay/portal/instance/lifecycle/PortalInstanceLifecycleListener.java
@@ -38,6 +38,10 @@ public interface PortalInstanceLifecycleListener {
 		return clazz.getName();
 	}
 
+	public default void portalInstanceNotRegistered(Company company)
+		throws Exception {
+	}
+
 	public default void portalInstancePreregistered(Company company)
 		throws Exception {
 	}

--- a/modules/apps/portal/portal-instance-lifecycle-impl/src/main/java/com/liferay/portal/instance/lifecycle/internal/PortalInstanceLifecycleListenerManagerImpl.java
+++ b/modules/apps/portal/portal-instance-lifecycle-impl/src/main/java/com/liferay/portal/instance/lifecycle/internal/PortalInstanceLifecycleListenerManagerImpl.java
@@ -110,6 +110,16 @@ public class PortalInstanceLifecycleListenerManagerImpl
 
 	@Clusterable
 	@Override
+	public void undoPreregisteredChanges(Company company) {
+		for (PortalInstanceLifecycleListener portalInstanceLifecycleListener :
+				_serviceTrackerList) {
+
+			undoPreregisteredChanges(portalInstanceLifecycleListener, company);
+		}
+	}
+
+	@Clusterable
+	@Override
 	public void unregisterCompany(Company company) {
 		_companies.remove(company);
 
@@ -212,6 +222,24 @@ public class PortalInstanceLifecycleListenerManagerImpl
 					LocaleThreadLocal.setSiteDefaultLocale(siteDefaultLocale);
 				}
 			});
+	}
+
+	protected void undoPreregisteredChanges(
+		PortalInstanceLifecycleListener portalInstanceLifecycleListener,
+		Company company) {
+
+		try {
+			portalInstanceLifecycleListener.portalInstanceNotRegistered(
+				company);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to undo pre registered portal instance changes " +
+						company,
+					exception);
+			}
+		}
 	}
 
 	protected void unregisterCompany(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/creation/instance/lifecycle/WorkflowMetricsIndexPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/creation/instance/lifecycle/WorkflowMetricsIndexPortalInstanceLifecycleListener.java
@@ -30,6 +30,11 @@ public class WorkflowMetricsIndexPortalInstanceLifecycleListener
 	extends BasePortalInstanceLifecycleListener {
 
 	@Override
+	public void portalInstanceNotRegistered(Company company) throws Exception {
+		_workflowMetricsIndexCreator.removeIndex(company);
+	}
+
+	@Override
 	public void portalInstancePreregistered(Company company) throws Exception {
 		_workflowMetricsIndexCreator.createIndex(company);
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1453,6 +1453,15 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		}
 	}
 
+	protected void undoCompanyPreregisteredChanges(Company company) {
+		PortalInstanceLifecycleManager portalInstanceLifecycleManager =
+			_serviceTracker.getService();
+
+		if (portalInstanceLifecycleManager != null) {
+			portalInstanceLifecycleManager.undoPreregisteredChanges(company);
+		}
+	}
+
 	protected void unregisterCompany(Company company) {
 		PortalInstanceLifecycleManager portalInstanceLifecycleManager =
 			_serviceTracker.getService();
@@ -2079,6 +2088,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			_portalPreferencesLocalService.getPreferences(
 				company.getCompanyId(), PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+		}
+		catch (Exception exception) {
+			undoCompanyPreregisteredChanges(company);
+
+			throw exception;
 		}
 		finally {
 			LocaleThreadLocal.setDefaultLocale(localeThreadLocalDefaultLocale);

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/lifecycle/PortalInstanceLifecycleManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/lifecycle/PortalInstanceLifecycleManager.java
@@ -30,6 +30,8 @@ public interface PortalInstanceLifecycleManager {
 
 	public void registerCompany(Company company);
 
+	public void undoPreregisteredChanges(Company company);
+
 	public void unregisterCompany(Company company);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/lifecycle/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/lifecycle/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

## Motivations

[Failing virtual instance creation leaves behind orphaned workflow metrics indexes](https://liferay.atlassian.net/browse/LPS-189313)

## Proposed Solution

Providing a method that will be called on failing company creation, 

this way we can make sure that when a company was not registered so we will be able to revert the changes applied by `portalInstancePreRegistered` method ([see](https://github.com/liferay/liferay-portal/blob/1f9c3cc0c0024a8e12b7643afa953e86a2da082c/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L1981)).

Another suggested approach is to use the `portalInstanceRegistered` method, as it will be called after the transaction ([see](https://github.com/liferay/liferay-portal/blob/1f9c3cc0c0024a8e12b7643afa953e86a2da082c/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L2080-L2085)), 

but for Workflow Metrics I believe we can't do this because it will cause intermittent errors on [reindex](https://github.com/liferay/liferay-portal/blob/bd7145551c94c4e768c7f070cfbe243293169865/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/creation/instance/lifecycle/WorkflowMetricsIndexPortalInstanceLifecycleListener.java#L44) like:

`ElasticsearchStatusException[Elasticsearch exception [type=index_not_found_exception, reason=no such index […]]]`

Thank you,
Feliphe Marinho